### PR TITLE
Fix OBS shutdown and signaling teardown

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -20,6 +20,7 @@ OBS_MODULE_USE_DEFAULT_LOCALE("obs-vdoninja", "en-US")
 
 #include <rtc/global.hpp>
 
+#include <QPointer>
 #include <cctype>
 #include <cstring>
 #include <filesystem>
@@ -77,7 +78,8 @@ struct ServiceSnapshot {
 obs_source_t *gControlCenterSource = nullptr;
 ServiceSnapshot gLastNonVdoServiceSnapshot = {};
 ServiceSnapshot gTemporaryRestoreSnapshot = {};
-VDONinjaDock *g_vdo_dock = nullptr;
+QPointer<VDONinjaDock> g_vdo_dock;
+bool g_frontend_exiting = false;
 
 constexpr const char *kVdoNinjaRtmpServiceEntry = R"VDOJSON(
         {
@@ -973,6 +975,22 @@ void backupServiceForTemporaryRestore(obs_service_t *service)
 	}
 
 	clearTemporaryServiceRestoreBackup();
+}
+
+void destroyVdoDock(bool removeFromFrontend)
+{
+	VDONinjaDock *dock = g_vdo_dock.data();
+	if (!dock) {
+		g_vdo_dock = nullptr;
+		return;
+	}
+
+	dock->shutdown();
+	if (removeFromFrontend) {
+		obs_frontend_remove_dock("VDONinjaStudioDock");
+	}
+	delete dock;
+	g_vdo_dock = nullptr;
 }
 
 bool restoreServiceFromTemporaryBackupIfNeeded()
@@ -2004,6 +2022,10 @@ static void frontend_event_callback(enum obs_frontend_event event, void *)
 		ensureStreamingServiceExists();
 		captureLastNonVdoServiceSnapshot(obs_frontend_get_streaming_service());
 		break;
+	case OBS_FRONTEND_EVENT_EXIT:
+		g_frontend_exiting = true;
+		destroyVdoDock(true);
+		break;
 	default:
 		break;
 	}
@@ -2105,11 +2127,11 @@ bool obs_module_load(void)
 
 	// Create and register Studio Dock
 	g_vdo_dock = new VDONinjaDock();
-	if (obs_frontend_add_custom_qdock("VDONinjaStudioDock", g_vdo_dock)) {
+	if (obs_frontend_add_custom_qdock("VDONinjaStudioDock", g_vdo_dock.data())) {
 		logInfo("Registered VDO.Ninja Studio Dock");
 	} else {
 		logWarning("Failed to register VDO.Ninja Studio Dock");
-		delete g_vdo_dock;
+		delete g_vdo_dock.data();
 		g_vdo_dock = nullptr;
 	}
 
@@ -2129,18 +2151,16 @@ void obs_module_unload(void)
 {
 	logInfo("Unloading VDO.Ninja plugin");
 
-	obs_frontend_remove_event_callback(frontend_event_callback, nullptr);
+	if (!g_frontend_exiting) {
+		obs_frontend_remove_event_callback(frontend_event_callback, nullptr);
+	}
 
 	if (gControlCenterSource) {
 		obs_source_release(gControlCenterSource);
 		gControlCenterSource = nullptr;
 	}
 
-	if (g_vdo_dock) {
-		obs_frontend_remove_dock("VDONinjaStudioDock");
-		delete g_vdo_dock;
-		g_vdo_dock = nullptr;
-	}
+	destroyVdoDock(!g_frontend_exiting);
 
 	releaseServiceSnapshot(gTemporaryRestoreSnapshot);
 	releaseServiceSnapshot(gLastNonVdoServiceSnapshot);

--- a/src/vdoninja-dock.cpp
+++ b/src/vdoninja-dock.cpp
@@ -60,9 +60,17 @@ VDONinjaDock::VDONinjaDock(QWidget *parent) : QDockWidget(parent)
 	});
 }
 
-VDONinjaDock::~VDONinjaDock()
+VDONinjaDock::~VDONinjaDock() {}
+
+void VDONinjaDock::shutdown()
 {
 	saveSettings();
+	if (statsTimer) {
+		statsTimer->stop();
+	}
+	if (chatClearTimer) {
+		chatClearTimer->stop();
+	}
 }
 
 void VDONinjaDock::setupUi()

--- a/src/vdoninja-dock.h
+++ b/src/vdoninja-dock.h
@@ -23,6 +23,7 @@ public:
 	explicit VDONinjaDock(QWidget *parent = nullptr);
 	~VDONinjaDock();
 	void syncFromActiveService();
+	void shutdown();
 
 	// Called from output thread (via obs_queue_task) to show chat messages
 	void onChatReceived(const QString &sender, const QString &message);

--- a/src/vdoninja-peer-manager.cpp
+++ b/src/vdoninja-peer-manager.cpp
@@ -1489,12 +1489,12 @@ void VDONinjaPeerManager::bundleAndSendCandidates(const std::string &uuid)
 
 	// Send all bundled candidates
 	for (const auto &cand : bundle.candidates) {
-		if (signalingDataChannel) {
-			signaling_->sendIceCandidateViaDataChannel(signalingDataChannel, uuid, std::get<0>(cand), std::get<1>(cand),
-			                                           bundle.session);
-		} else {
-			signaling_->sendIceCandidate(uuid, std::get<0>(cand), std::get<1>(cand), bundle.session);
+		if (signalingDataChannel &&
+		    signaling_->sendIceCandidateViaDataChannel(signalingDataChannel, uuid, std::get<0>(cand), std::get<1>(cand),
+		                                               bundle.session)) {
+			continue;
 		}
+		signaling_->sendIceCandidate(uuid, std::get<0>(cand), std::get<1>(cand), bundle.session);
 	}
 
 	logDebug("Sent %zu bundled ICE candidates to %s", bundle.candidates.size(), uuid.c_str());
@@ -1831,6 +1831,9 @@ void VDONinjaPeerManager::sendDataToAll(const std::string &message)
 		}
 		try {
 			if (pair.second->hasDataChannel && pair.second->dataChannel) {
+				if (!pair.second->dataChannel->isOpen()) {
+					continue;
+				}
 				pair.second->dataChannel->send(message);
 			}
 		} catch (const std::exception &e) {
@@ -1851,10 +1854,16 @@ void VDONinjaPeerManager::sendDataToPeer(const std::string &uuid, const std::str
 
 	try {
 		if (it->second->hasDataChannel && it->second->dataChannel) {
+			if (!it->second->dataChannel->isOpen()) {
+				return;
+			}
 			it->second->dataChannel->send(message);
 			return;
 		}
 		if (it->second->type == ConnectionType::Viewer && it->second->signalingDataChannel) {
+			if (!it->second->signalingDataChannel->isOpen()) {
+				return;
+			}
 			it->second->signalingDataChannel->send(wrapTargetedPeerMessage(uuid, it->second->session, message));
 		}
 	} catch (const std::exception &e) {

--- a/src/vdoninja-signaling.cpp
+++ b/src/vdoninja-signaling.cpp
@@ -726,11 +726,21 @@ void VDONinjaSignaling::wsThreadFunc()
 					sendQueue_.pop();
 					lock.unlock();
 
+					if (!shouldRun_ || !connected_ || !ws->isOpen()) {
+						logDebug("Dropping queued signaling message because WebSocket is closed");
+						lock.lock();
+						continue;
+					}
+
 					try {
 						ws->send(msg);
 						logDebug("Sent: %s", msg.c_str());
 					} catch (const std::exception &e) {
-						logError("Failed to send message: %s", e.what());
+						if (shouldRun_ && connected_ && ws->isOpen()) {
+							logError("Failed to send message: %s", e.what());
+						} else {
+							logDebug("Dropping queued signaling message during WebSocket shutdown: %s", e.what());
+						}
 					}
 
 					lock.lock();
@@ -1301,27 +1311,19 @@ bool VDONinjaSignaling::publishStream(const std::string &streamId, const std::st
 
 bool VDONinjaSignaling::unpublishStream()
 {
-	std::string hashedStreamId;
 	{
 		std::lock_guard<std::mutex> lock(stateMutex_);
 		if (!publishedStream_.isPublishing) {
 			return true;
 		}
-		hashedStreamId = publishedStream_.hashedStreamId;
 	}
-
-	JsonBuilder msg;
-	msg.add("request", "unseed");
-	msg.add("streamID", hashedStreamId);
-
-	sendMessage(msg.build());
 
 	{
 		std::lock_guard<std::mutex> lock(stateMutex_);
 		publishedStream_ = StreamInfo{};
 	}
 
-	logInfo("Unpublished stream");
+	logInfo("Cleared published stream state");
 	return true;
 }
 
@@ -1600,12 +1602,12 @@ void VDONinjaSignaling::sendIceCandidate(const std::string &uuid, const std::str
 	logDebug("Sent ICE candidate to %s", uuid.c_str());
 }
 
-void VDONinjaSignaling::sendIceCandidateViaDataChannel(const std::shared_ptr<rtc::DataChannel> &dc,
+bool VDONinjaSignaling::sendIceCandidateViaDataChannel(const std::shared_ptr<rtc::DataChannel> &dc,
                                                        const std::string &uuid, const std::string &candidate,
                                                        const std::string &mid, const std::string &session)
 {
-	if (!dc) {
-		return;
+	if (!dc || !dc->isOpen()) {
+		return false;
 	}
 
 	std::string salt;
@@ -1652,8 +1654,14 @@ void VDONinjaSignaling::sendIceCandidateViaDataChannel(const std::shared_ptr<rtc
 		msg.addRaw("candidate", candidateObj.build());
 	}
 
-	dc->send(msg.build());
-	logDebug("Sent ICE candidate to %s via datachannel", uuid.c_str());
+	try {
+		dc->send(msg.build());
+		logDebug("Sent ICE candidate to %s via datachannel", uuid.c_str());
+		return true;
+	} catch (const std::exception &e) {
+		logDebug("Failed to send ICE candidate to %s via datachannel: %s", uuid.c_str(), e.what());
+	}
+	return false;
 }
 
 void VDONinjaSignaling::sendDataMessage(const std::string &uuid, const std::string &data)

--- a/src/vdoninja-signaling.h
+++ b/src/vdoninja-signaling.h
@@ -69,7 +69,7 @@ public:
 	                      const std::string &session);
 	void sendAnswerViaDataChannel(const std::shared_ptr<rtc::DataChannel> &dc, const std::string &uuid,
 	                              const std::string &sdp, const std::string &session);
-	void sendIceCandidateViaDataChannel(const std::shared_ptr<rtc::DataChannel> &dc, const std::string &uuid,
+	bool sendIceCandidateViaDataChannel(const std::shared_ptr<rtc::DataChannel> &dc, const std::string &uuid,
 	                                    const std::string &candidate, const std::string &mid,
 	                                    const std::string &session);
 

--- a/src/vdoninja-source.cpp
+++ b/src/vdoninja-source.cpp
@@ -422,6 +422,10 @@ bool safeRequestKeyframe(const std::shared_ptr<rtc::Track> &track, const char *r
 	}
 
 	try {
+		if (!track->isOpen()) {
+			logDebug("Skipping video keyframe request (%s): track is not open", reasonTag);
+			return false;
+		}
 		return track->requestKeyframe();
 	} catch (const std::exception &e) {
 		logWarning("Failed to request video keyframe (%s): %s", reasonTag, e.what());
@@ -439,6 +443,10 @@ bool safeRequestBitrate(const std::shared_ptr<rtc::Track> &track, unsigned int b
 	}
 
 	try {
+		if (!track->isOpen()) {
+			logDebug("Skipping video bitrate request (%s): track is not open", reasonTag);
+			return false;
+		}
 		return track->requestBitrate(bitrateBps);
 	} catch (const std::exception &e) {
 		logWarning("Failed to request video bitrate (%s): %s", reasonTag, e.what());
@@ -1852,8 +1860,14 @@ void VDONinjaSource::processVideoData(const uint8_t *data, size_t size, uint32_t
 	std::memcpy(videoPacket_->data, data, size);
 	const int sendResult = avcodec_send_packet(videoDecoder_, videoPacket_);
 	if (sendResult < 0 && sendResult != AVERROR(EAGAIN)) {
-		logWarning("Failed to submit %s packet: %s", codecName, ffmpegErrorString(sendResult).c_str());
-		if (safeRequestKeyframe(currentVideoTrack, "send-packet-failure")) {
+		if (!loggedVideoDecodeSubmitFailure_.exchange(true, std::memory_order_relaxed)) {
+			logWarning("Failed to submit %s packet before a decodable keyframe arrived: %s", codecName,
+			           ffmpegErrorString(sendResult).c_str());
+		}
+		const int64_t now = currentTimeMs();
+		const int64_t lastKeyframeRequestTime = lastKeyframeRequestTime_.load(std::memory_order_relaxed);
+		if ((lastKeyframeRequestTime == 0 || now - lastKeyframeRequestTime >= 1000) &&
+		    safeRequestKeyframe(currentVideoTrack, "send-packet-failure")) {
 			lastKeyframeRequestTime_.store(currentTimeMs(), std::memory_order_relaxed);
 		}
 		return;
@@ -2481,6 +2495,7 @@ void VDONinjaSource::resetVideoDecoder()
 	lastDecodedVideoWidth_ = 0;
 	lastDecodedVideoHeight_ = 0;
 	pendingVideoDecodeTimestamps_.clear();
+	loggedVideoDecodeSubmitFailure_.store(false, std::memory_order_relaxed);
 	videoHwDecodeConfigured_ = false;
 	videoHwStatusLogged_ = false;
 	videoHwPixelFormat_ = AV_PIX_FMT_NONE;

--- a/src/vdoninja-source.h
+++ b/src/vdoninja-source.h
@@ -135,6 +135,7 @@ private:
 	std::atomic<bool> loggedFirstVideoRtpPacket_{false};
 	std::atomic<bool> loggedFirstVideoPacket_{false};
 	std::atomic<bool> loggedFirstDecodedVideoFrame_{false};
+	std::atomic<bool> loggedVideoDecodeSubmitFailure_{false};
 	std::atomic<bool> loggedFirstAudioPacket_{false};
 	std::atomic<bool> loggedFirstDecodedAudioFrame_{false};
 	std::atomic<bool> loggedFirstDecodedAlphaFrame_{false};


### PR DESCRIPTION
## Summary
- clean up the Studio Dock during OBS frontend exit and non-exit module unload paths
- remove the nonexistent `unseed` signaling request from stream unpublish
- guard websocket, data channel, and track sends during shutdown/reconnect races
- fall back ICE candidate delivery to websocket when the signaling data channel is unavailable
- throttle expected VP9 pre-keyframe decode warnings during startup

## Validation
- `ctest --test-dir build-codex-tests --output-on-failure` (298/298 passed)
- `find src tests -name "*.cpp" -o -name "*.h" | xargs /opt/homebrew/opt/llvm/bin/clang-format --dry-run --Werror`
- plugin build against local OBS/libdatachannel SDK config
- OBS publish/native-source e2e validation
- focused OBS soak: 60/60 cycles with scene switching, text overlays, temporary overlays, and repeated stream start/stop
- OBS shutdown reported `Number of memory leaks: 0`

## Notes
- The direct OBS Browser Source control still rendered black in this local OBS build/session, while a direct color source and the plugin native source rendered correctly. That points at the local OBS Browser Source/CEF path rather than this plugin.