### PR TITLE
Fix macOS TLS signaling failure by shipping a CA trust store (v1.1.55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.55] - 2026-07-25
+
+### Fixed
+- Shipped a CA-certificate bundle inside the macOS plugin and pointed the signaling TLS client at it — honoring an `SSL_CERT_FILE` override and falling back to common system trust stores — so WebSocket signaling no longer fails with "TLS connection failed" on Macs that lack a Homebrew OpenSSL trust store.
+
 ## [1.1.54] - 2026-07-19
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(obs-vdoninja VERSION 1.1.54 LANGUAGES C CXX)
+project(obs-vdoninja VERSION 1.1.55 LANGUAGES C CXX)
 
 # Plugin configuration
 set(PLUGIN_AUTHOR "VDO.Ninja Community")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ninja-plugin",
-  "version": "1.1.54",
+  "version": "1.1.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ninja-plugin",
-      "version": "1.1.54",
+      "version": "1.1.55",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@playwright/test": "^1.58.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ninja-plugin",
-  "version": "1.1.54",
+  "version": "1.1.55",
   "description": "OBS VDO.Ninja plugin",
   "main": "index.js",
   "directories": {

--- a/scripts/build-installer-macos.sh
+++ b/scripts/build-installer-macos.sh
@@ -209,6 +209,38 @@ for dylib in "$SRC_PLUGIN_DIR"/*.dylib; do
   [[ -f "$dylib" ]] && cp -a "$dylib" "$DST_PLUGIN_DIR/"
 done
 
+# Ship a CA-certificate bundle next to the plugin binary so the bundled
+# OpenSSL can verify TLS peers on machines that do not provide their own
+# trust store (e.g. a Mac without Homebrew's openssl@3 cert.pem). The plugin
+# looks for this exact filename alongside its binary at runtime.
+CA_BUNDLE_NAME="vdoninja-ca-bundle.pem"
+CA_BUNDLE_SRC="${OBS_VDONINJA_CA_BUNDLE:-}"
+if [[ -z "$CA_BUNDLE_SRC" ]]; then
+  ca_candidates=()
+  if command -v brew >/dev/null 2>&1; then
+    for formula in openssl@3 ca-certificates; do
+      prefix="$(brew --prefix "$formula" 2>/dev/null || true)"
+      [[ -n "$prefix" ]] || continue
+      ca_candidates+=("$prefix/etc/openssl@3/cert.pem" "$prefix/etc/ca-certificates/cert.pem" \
+        "$prefix/share/ca-certificates/cacert.pem")
+    done
+  fi
+  ca_candidates+=(/opt/homebrew/etc/openssl@3/cert.pem /usr/local/etc/openssl@3/cert.pem /etc/ssl/cert.pem)
+  for candidate in "${ca_candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      CA_BUNDLE_SRC="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -n "$CA_BUNDLE_SRC" && -f "$CA_BUNDLE_SRC" ]]; then
+  # Follow symlinks (Homebrew's cert.pem is usually a symlink into ca-certificates).
+  cp -aL "$CA_BUNDLE_SRC" "$DST_PLUGIN_DIR/$CA_BUNDLE_NAME"
+  echo "Bundled CA certificate store from $CA_BUNDLE_SRC"
+else
+  echo "Warning: no CA certificate bundle found to ship with the plugin; TLS may rely on the host trust store." >&2
+fi
+
 cat > "$BUNDLE_DIR/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/src/plugin-main.h
+++ b/src/plugin-main.h
@@ -7,7 +7,7 @@
 
 #include <obs-module.h>
 
-#define PLUGIN_VERSION "1.1.54"
+#define PLUGIN_VERSION "1.1.55"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/vdoninja-signaling.cpp
+++ b/src/vdoninja-signaling.cpp
@@ -15,10 +15,20 @@
 #include <array>
 #include <cctype>
 #include <chrono>
+#include <cstdlib>
 #include <cwchar>
+#include <fstream>
 #include <initializer_list>
 #include <new>
+#include <string>
 #include <vector>
+
+#if defined(__APPLE__) || defined(__linux__) || defined(__unix__)
+#define VDONINJA_HAS_DLADDR 1
+#include <dlfcn.h>
+#else
+#define VDONINJA_HAS_DLADDR 0
+#endif
 
 #if __has_include(<openssl/evp.h>) && __has_include(<openssl/rand.h>)
 #define VDONINJA_HAS_OPENSSL 1
@@ -53,6 +63,57 @@ constexpr int kSignalingConnectionTimeoutMs = 4000;
 #ifdef TESTING_BUILD
 std::atomic<bool> gForceEncryptionFailureForTesting{false};
 #endif
+
+bool fileIsReadable(const std::string &path)
+{
+	if (path.empty()) {
+		return false;
+	}
+	std::ifstream stream(path, std::ios::binary);
+	return stream.good();
+}
+
+// Returns directories to search for a CA bundle shipped alongside this module.
+// The plugin binary's own directory is the primary location; on macOS the CA
+// bundle is installed there next to obs-vdoninja inside the .plugin bundle.
+std::vector<std::string> moduleDirectories()
+{
+	std::vector<std::string> dirs;
+#if VDONINJA_HAS_DLADDR
+	Dl_info info{};
+	// Use the address of a symbol defined in this shared object so dladdr
+	// resolves to the plugin module rather than to libc or another library.
+	if (dladdr(reinterpret_cast<const void *>(&fileIsReadable), &info) != 0 && info.dli_fname != nullptr) {
+		std::string modulePath = info.dli_fname;
+		const std::string::size_type slash = modulePath.find_last_of('/');
+		if (slash != std::string::npos) {
+			dirs.push_back(modulePath.substr(0, slash));
+		}
+	}
+#endif
+	return dirs;
+}
+
+// Resolves the CA-certificate bundle to hand to the TLS layer, or an empty
+// string to fall back to OpenSSL's compiled-in default trust store. Probes an
+// explicit SSL_CERT_FILE override, a bundle shipped with the plugin, then
+// well-known system locations. Computed once and cached.
+const std::string &resolveCaCertificateFile()
+{
+	static const std::string cached = []() -> std::string {
+		std::string envCertFile;
+		if (const char *env = std::getenv("SSL_CERT_FILE")) {
+			envCertFile = env;
+		}
+		for (const std::string &candidate : buildCaCertificateCandidatePaths(envCertFile, moduleDirectories())) {
+			if (fileIsReadable(candidate)) {
+				return candidate;
+			}
+		}
+		return std::string();
+	}();
+	return cached;
+}
 
 template <typename Fn> void runRtcCallbackNoexcept(const char *context, Fn &&fn)
 {
@@ -610,7 +671,19 @@ void VDONinjaSignaling::wsThreadFunc()
 			wsConfig.connectionTimeout = std::chrono::milliseconds(kSignalingConnectionTimeoutMs);
 			wsConfig.pingInterval.reset();
 			wsConfig.maxOutstandingPings.reset();
-			wsConfig.caCertificatePemFile.reset();
+			// Point OpenSSL at an explicit CA bundle when one is available so a
+			// self-contained build can verify TLS peers even on machines that
+			// do not provide OpenSSL's default trust store (e.g. macOS without
+			// Homebrew). Falls back to the compiled-in default when empty.
+			{
+				const std::string &caFile = resolveCaCertificateFile();
+				if (caFile.empty()) {
+					wsConfig.caCertificatePemFile.reset();
+				} else {
+					wsConfig.caCertificatePemFile = caFile;
+					logDebug("Using CA certificate bundle for signaling TLS: %s", caFile.c_str());
+				}
+			}
 			wsConfig.certificatePemFile.reset();
 			wsConfig.keyPemFile.reset();
 			wsConfig.keyPemPass.reset();

--- a/src/vdoninja-utils.cpp
+++ b/src/vdoninja-utils.cpp
@@ -1390,6 +1390,54 @@ const char *signalingConnectErrorLikelyCauses(SignalingConnectErrorCategory cate
 	}
 }
 
+std::vector<std::string> buildCaCertificateCandidatePaths(const std::string &sslCertFileEnv,
+                                                          const std::vector<std::string> &moduleDirs)
+{
+	std::vector<std::string> candidates;
+	auto addCandidate = [&candidates](const std::string &path) {
+		if (path.empty()) {
+			return;
+		}
+		if (std::find(candidates.begin(), candidates.end(), path) != candidates.end()) {
+			return;
+		}
+		candidates.push_back(path);
+	};
+
+	// 1. Explicit user/environment override wins.
+	addCandidate(trim(sslCertFileEnv));
+
+	// 2. A CA bundle shipped next to the plugin binary. On macOS the plugin
+	//    lives at <bundle>/Contents/MacOS/obs-vdoninja, so also probe the
+	//    sibling Resources/data directory used for plugin resources.
+	for (const std::string &dir : moduleDirs) {
+		std::string base = trim(dir);
+		while (base.size() > 1 && base.back() == '/') {
+			base.pop_back();
+		}
+		if (base.empty()) {
+			continue;
+		}
+		addCandidate(base + "/" + kBundledCaCertificateFileName);
+		addCandidate(base + "/../Resources/data/" + kBundledCaCertificateFileName);
+	}
+
+	// 3. Well-known system trust stores as a last resort.
+	static const char *const kSystemCaBundles[] = {
+	    "/etc/ssl/cert.pem",                    // macOS, some BSDs
+	    "/etc/ssl/certs/ca-certificates.crt",   // Debian/Ubuntu/Alpine
+	    "/etc/pki/tls/certs/ca-bundle.crt",     // RHEL/Fedora/CentOS
+	    "/etc/ssl/ca-bundle.pem",               // openSUSE
+	    "/usr/local/etc/openssl@3/cert.pem",    // Intel Homebrew OpenSSL 3
+	    "/opt/homebrew/etc/openssl@3/cert.pem", // Apple Silicon Homebrew OpenSSL 3
+	};
+	for (const char *path : kSystemCaBundles) {
+		addCandidate(path);
+	}
+
+	return candidates;
+}
+
 // Time utilities
 int64_t currentTimeMs()
 {

--- a/src/vdoninja-utils.h
+++ b/src/vdoninja-utils.h
@@ -134,6 +134,20 @@ SignalingConnectErrorCategory classifySignalingConnectError(const std::string &e
 const char *signalingConnectErrorCategoryName(SignalingConnectErrorCategory category);
 const char *signalingConnectErrorLikelyCauses(SignalingConnectErrorCategory category);
 
+// Filename of the CA-certificate bundle shipped alongside the plugin binary so
+// that a self-contained OpenSSL build can verify TLS peers on machines that do
+// not provide their own trust store (e.g. macOS without Homebrew). The macOS
+// installer copies the bundle next to the plugin under this exact name.
+inline constexpr const char *kBundledCaCertificateFileName = "vdoninja-ca-bundle.pem";
+
+// Builds an ordered list of candidate CA-bundle file paths to try for TLS
+// verification. Precedence: an explicit SSL_CERT_FILE override, then a bundle
+// shipped alongside the plugin module (checked in each provided module
+// directory), then well-known system locations. The caller probes the returned
+// paths in order and uses the first that exists. Duplicate paths are collapsed.
+std::vector<std::string> buildCaCertificateCandidatePaths(const std::string &sslCertFileEnv,
+                                                          const std::vector<std::string> &moduleDirs);
+
 // Time utilities
 int64_t currentTimeMs();
 std::string formatTimestamp(int64_t ms);

--- a/tests/test-utils.cpp
+++ b/tests/test-utils.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+#include <algorithm>
 #include <regex>
 #include <set>
 #include <thread>
@@ -399,6 +400,77 @@ TEST(SignalingConnectErrorTest, FallsBackToUnknownForUnclassifiedErrors)
 	EXPECT_STREQ(signalingConnectErrorLikelyCauses(SignalingConnectErrorCategory::Unknown),
 	             "check the surrounding [VDO.Ninja/RTC] lines; likely candidates are DNS/routing issues, TLS "
 	             "interception, or the remote closing before WebSocket open");
+}
+
+// CA certificate bundle resolution
+static bool containsPath(const std::vector<std::string> &paths, const std::string &value)
+{
+	return std::find(paths.begin(), paths.end(), value) != paths.end();
+}
+
+TEST(CaCertificateCandidatesTest, EnvOverrideComesFirst)
+{
+	auto paths = buildCaCertificateCandidatePaths("/custom/ca.pem", {});
+	ASSERT_FALSE(paths.empty());
+	EXPECT_EQ(paths.front(), "/custom/ca.pem");
+}
+
+TEST(CaCertificateCandidatesTest, TrimsWhitespaceFromEnvOverride)
+{
+	auto paths = buildCaCertificateCandidatePaths("  /custom/ca.pem\n", {});
+	ASSERT_FALSE(paths.empty());
+	EXPECT_EQ(paths.front(), "/custom/ca.pem");
+}
+
+TEST(CaCertificateCandidatesTest, EmptyEnvIsSkipped)
+{
+	auto paths = buildCaCertificateCandidatePaths("   ", {});
+	for (const auto &p : paths) {
+		EXPECT_FALSE(p.empty());
+	}
+	// System fallbacks should still be present.
+	EXPECT_TRUE(containsPath(paths, "/etc/ssl/cert.pem"));
+}
+
+TEST(CaCertificateCandidatesTest, IncludesModuleAdjacentAndResourcesPaths)
+{
+	const std::string base = "/Applications/OBS.app/plugins/obs-vdoninja.plugin/Contents/MacOS";
+	auto paths = buildCaCertificateCandidatePaths("", {base});
+	EXPECT_TRUE(containsPath(paths, base + "/" + kBundledCaCertificateFileName));
+	EXPECT_TRUE(containsPath(paths, base + "/../Resources/data/" + kBundledCaCertificateFileName));
+}
+
+TEST(CaCertificateCandidatesTest, StripsTrailingSlashesFromModuleDir)
+{
+	auto paths = buildCaCertificateCandidatePaths("", {"/opt/plugin/MacOS///"});
+	EXPECT_TRUE(containsPath(paths, std::string("/opt/plugin/MacOS/") + kBundledCaCertificateFileName));
+}
+
+TEST(CaCertificateCandidatesTest, ModuleBundlePrecedesSystemPaths)
+{
+	auto paths = buildCaCertificateCandidatePaths("", {"/opt/plugin/MacOS"});
+	auto moduleIt =
+	    std::find(paths.begin(), paths.end(), std::string("/opt/plugin/MacOS/") + kBundledCaCertificateFileName);
+	auto systemIt = std::find(paths.begin(), paths.end(), std::string("/etc/ssl/cert.pem"));
+	ASSERT_NE(moduleIt, paths.end());
+	ASSERT_NE(systemIt, paths.end());
+	EXPECT_LT(moduleIt - paths.begin(), systemIt - paths.begin());
+}
+
+TEST(CaCertificateCandidatesTest, DeduplicatesRepeatedPaths)
+{
+	auto paths = buildCaCertificateCandidatePaths("/etc/ssl/cert.pem", {});
+	std::set<std::string> unique(paths.begin(), paths.end());
+	EXPECT_EQ(unique.size(), paths.size());
+	EXPECT_EQ(paths.front(), "/etc/ssl/cert.pem");
+}
+
+TEST(CaCertificateCandidatesTest, IncludesKnownSystemBundles)
+{
+	auto paths = buildCaCertificateCandidatePaths("", {});
+	EXPECT_TRUE(containsPath(paths, "/etc/ssl/cert.pem"));
+	EXPECT_TRUE(containsPath(paths, "/etc/ssl/certs/ca-certificates.crt"));
+	EXPECT_TRUE(containsPath(paths, "/opt/homebrew/etc/openssl@3/cert.pem"));
 }
 
 // Base64 Encoding/Decoding Tests


### PR DESCRIPTION
## Summary

Fixes the `Built-in signaling server fallback failed; primary error: TLS connection failed; fallback error: TLS connection failed` error some macOS users hit when the signaling WebSocket connects to `wss.vdo.ninja` (and the `proxywss.rtc.ninja` fallback). The same stream ID worked from phones and Windows on the same network — the failure was client-side TLS trust, not connectivity or the stream ID.

## Root cause

The plugin left `wsConfig.caCertificatePemFile.reset()`, so libdatachannel's bundled OpenSSL relied entirely on its **compiled-in** `OPENSSLDIR` (e.g. `/opt/homebrew/etc/openssl@3/cert.pem`). That path is created by Homebrew's `openssl@3`/`ca-certificates` formulae — it does **not** exist on an end-user Mac without Homebrew. With no trust anchors, every certificate failed verification and the handshake surfaced the generic `TLS connection failed`, for both the primary and fallback host. Dev/test Macs (which have `brew install openssl@3`) had the bundle, which is why it passed testing. Phones and Windows use their own trust stores, so they were unaffected.

## Changes

- **`src/vdoninja-signaling.cpp`** — resolve a CA bundle at connect time and pass it via `caCertificatePemFile` instead of always resetting it. Precedence: `SSL_CERT_FILE` override → a bundle shipped next to the plugin binary (resolved via `dladdr`) → well-known system trust stores. Falls back to OpenSSL's defaults when none is found, so working setups are untouched (Windows behavior unchanged). Result is computed once and cached.
- **`src/vdoninja-utils.{h,cpp}`** — new pure, unit-tested `buildCaCertificateCandidatePaths()` that builds the ordered candidate list, plus the shared bundled-filename constant.
- **`scripts/build-installer-macos.sh`** — ship a `vdoninja-ca-bundle.pem` inside the macOS `.plugin` (next to the binary), sourced from Homebrew's cert store (overridable via `OBS_VDONINJA_CA_BUNDLE`), so a self-contained install can verify TLS peers without Homebrew.
- **`tests/test-utils.cpp`** — 8 new tests covering override precedence, module/Resources paths, trailing-slash normalization, dedup, and system-bundle inclusion.
- Version bumped to **1.1.55** across CMake / `plugin-main.h` / `package.json` / `package-lock.json`, with a CHANGELOG entry.

## Testing

- `BUILD_TESTS=ON BUILD_PLUGIN=OFF` build is clean; full suite **477/477 passing** (including the 8 new CA-resolution tests).
- `clang-format` clean on all changed files.
- Full macOS/Windows signed+notarized build runs in CI when the `v1.1.55` tag is pushed after merge.

## Workaround for affected users (pre-release)

Launch OBS with an explicit CA file to confirm the diagnosis:

```
SSL_CERT_FILE=/etc/ssl/cert.pem /Applications/OBS.app/Contents/MacOS/OBS
```

`brew install openssl@3` also resolves it — which is exactly why it worked on dev machines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzbywdTwrPC9XaSjYEuZMu)_